### PR TITLE
Fix theme toggle button text initialization to use the correct initial theme

### DIFF
--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -15,7 +15,7 @@ function initializeTheme() {
   // Apply the initial theme to the document
   document.body.classList.remove("light-mode", "dark-mode");
   document.body.classList.add(`${initialTheme}-mode`);
-  toggleBtn.innerText = savedTheme === "dark" ? "Light Mode" : "Dark Mode";
+  toggleBtn.innerText = initialTheme === "dark" ? "Light Mode" : "Dark Mode";
 
   // Handle user-initiated theme toggle
   toggleBtn.addEventListener("click", () => {


### PR DESCRIPTION
After resolving the system default and any stored preference into an `initialTheme`, use `initialTheme` to determine whether to display dark or light mode — rather than relying directly on `savedTheme`.

Fixes #28 